### PR TITLE
Added option to use `slug` instead of `name` as a key in netbox `dict` 

### DIFF
--- a/netbox/netbox.py
+++ b/netbox/netbox.py
@@ -124,6 +124,7 @@ class NetboxAsInventory(object):
         script_config = script_config_data.get(main_config_key)
         if script_config:
             self.api_url = script_config["main"].get('api_url')
+            self.identifier = script_config["main"].get('identifier')
             self.group_by = script_config.setdefault("group_by", {})
             self.hosts_vars = script_config.setdefault("hosts_vars", {})
         else:
@@ -132,7 +133,7 @@ class NetboxAsInventory(object):
 
         # Get value based on key.
         self.key_map = {
-            "default": "name",
+            "default": self.identifier,
             "general": "name",
             "custom": "value",
             "ip": "address"

--- a/netbox/netbox.py
+++ b/netbox/netbox.py
@@ -37,6 +37,7 @@ def cli_arguments():
                         default=os.getenv("NETBOX_CONFIG_FILE", "netbox.yml"),
                         help="""Path for script's configuration. Also "NETBOX_CONFIG_FILE"
                                 could be used as env var to set conf file path.""")
+    parser.add_argument("-v", "--version", action='version', version='%(prog)s 1.3')
     parser.add_argument("--list", help="Print all hosts with vars as Ansible dynamic inventory syntax.",
                         action="store_true")
     parser.add_argument("--host", help="Print specific host vars as Ansible dynamic inventory syntax.",

--- a/netbox/netbox.yml
+++ b/netbox/netbox.yml
@@ -3,7 +3,7 @@ netbox:
         api_url: 'http://localhost/api/dcim/devices/'
         # Preference for which `key` to be used when querying netbox for devices
         # (i.e. to use `slug` instead of `name`)
-        identifier: slug
+        identifier: name
 
     # How servers will be grouped.
     # If no group specified here, inventory script will return all servers.

--- a/netbox/netbox.yml
+++ b/netbox/netbox.yml
@@ -1,6 +1,9 @@
 netbox:
     main:
         api_url: 'http://localhost/api/dcim/devices/'
+        # Preference for which `key` to be used when querying netbox for devices
+        # (i.e. to use `slug` instead of `name`)
+        identifier: slug
 
     # How servers will be grouped.
     # If no group specified here, inventory script will return all servers.


### PR DESCRIPTION
This is my first Git "Fork / Pull" request so I apologize if I didn't follow protocol.

I implemented an option to to use `slug` as the key in netbox as I requested in issue https://github.com/AAbouZaid/netbox-as-ansible-inventory/issues/4.

Also, I thought it would be nice to add the `--version` to `argparse` to keep a handle on the progression of this code.

Feel free to change the variable names and comments I used in the `netbox.yml` file or even the entire method.  I'm not a developer by trade, so again, sorry in advance.