### PR TITLE
This PR supports nested group name.

### DIFF
--- a/netbox/netbox.py
+++ b/netbox/netbox.py
@@ -234,7 +234,7 @@ class NetboxAsInventory(object):
                 # The groups that will be used to group hosts in the inventory.
                 for group in groups_categories[category]:
                     # Try to get group value. If the section not found in netbox, this also will print error message.
-                    group_value = self._get_value_by_path(data_dict, [group, key_name])
+                    group_value = self._get_value_by_path(data_dict, group.split('.') + [key_name])
                     inventory_dict = self.add_host_to_group(server_name, group_value, inventory_dict)
 
         # If no groups in "group_by" section, the host will go to catch-all group.


### PR DESCRIPTION
Add support for grouping by nested group.
This patch splits group name with dot when get group value.
Example of nested group name is `device_type.manufacturer'.