### PR TITLE
Add option in config file to pass filter when querying list of hosts

### DIFF
--- a/netbox/netbox.py
+++ b/netbox/netbox.py
@@ -80,6 +80,7 @@ class NetboxAsInventory(object):
         self.script_config = script_config_data
         self.api_url = self._config(["main", "api_url"])
         self.group_by = self._config(["group_by"], default={})
+        self.filters = self._config(["filters"], default={})
         self.hosts_vars = self._config(["hosts_vars"], default={})
 
         # Get value based on key.
@@ -150,7 +151,7 @@ class NetboxAsInventory(object):
         return key_value
 
     @staticmethod
-    def get_hosts_list(api_url, specific_host=None):
+    def get_hosts_list(api_url, specific_host=None, filters={}):
         """Retrieves hosts list from netbox API.
 
         Returns:
@@ -164,6 +165,10 @@ class NetboxAsInventory(object):
             api_url_params = {"name": specific_host}
         else:
             api_url_params = {}
+
+        # Add filters provided into the URL
+        for key, value in filters.iteritems():
+            api_url_params[key] = value
 
         # Get hosts list.
         hosts_list = requests.get(api_url, params=api_url_params)
@@ -318,7 +323,7 @@ class NetboxAsInventory(object):
         """
 
         inventory_dict = dict()
-        netbox_hosts_list = self.get_hosts_list(self.api_url, self.host)
+        netbox_hosts_list = self.get_hosts_list(self.api_url, self.host, self.filters)
         if isinstance(netbox_hosts_list, dict) and "results" in netbox_hosts_list:
             netbox_hosts_list = netbox_hosts_list["results"]
 

--- a/netbox/netbox.yml
+++ b/netbox/netbox.yml
@@ -14,6 +14,11 @@ netbox:
         #custom:
         #    - env
 
+    # Add filters to limit the list of host that will be returned
+    # All parameters valid for the API (GET /api/dcim/devices/) are accepted
+    # filters:
+    #     site: dc1
+
     # Use Netbox sections as host variables.
     hosts_vars:
         # Sections related to IPs e.g. "primary_ip" or "primary_ip4".


### PR DESCRIPTION
Thanks for this project, it's very useful. I like how the configuration file is structured.
In our case, we have multiple sites sharing the same netbox server so in order to avoid everyone to query all hosts, I added an option in the config file to pass "filters".
The filters are just valid parameters for the GET /api/dcim/devices/ API

Please let me know if you are interested by this PR and if you have some comments.

_I still need to update the README with some info_