### PR TITLE
Basic support for slugs, names and labels in group_by and host_vars

### DIFF
--- a/netbox/netbox.py
+++ b/netbox/netbox.py
@@ -87,6 +87,9 @@ class NetboxAsInventory(object):
         self.key_map = {
             "default": "name",
             "general": "name",
+            "names": "name",
+            "slugs": "slug",
+            "labels": "value",
             "custom": "value",
             "ip": "address"
         }
@@ -236,6 +239,8 @@ class NetboxAsInventory(object):
         server_name = host_data.get("name")
         categories_source = {
             "default": host_data,
+            "names": host_data,
+            "slugs": host_data,
             "custom": host_data.get("custom_fields")
         }
 
@@ -280,6 +285,9 @@ class NetboxAsInventory(object):
             categories_source = {
                 "ip": host_data,
                 "general": host_data,
+                "names": host_data,
+                "slugs": host_data,
+                "labels": host_data,
                 "custom": host_data.get("custom_fields")
             }
 


### PR DESCRIPTION
Implements a very simple method for using `slug`, `name` and `label` fields from netbox API for group_by or host_vars as discussed in #4 and #22.

This is not likely to be the "best" approach as it requires authors of the `netbox.yml` configuration file to know which fields they want to group_by or use for host_vars are of which type.

This should be backwards compatible with existing YAML configurations.