### PR TITLE
Update test arg parsing to fix PyTest warning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,8 +40,9 @@ class PyTest(TestCommand):
         self.pytest_args = []
 
     def run_tests(self):
+        import shlex
         import pytest
-        errno = pytest.main(self.pytest_args)
+        errno = pytest.main(shlex.split(self.pytest_args))
         sys.exit(errno)
 
 


### PR DESCRIPTION
Update test arg parsing to fix PyTest "passing a string to pytest.main() is deprecated, pass a list of arguments instead." warning.

Based off best practice from https://docs.pytest.org/en/latest/goodpractices.html#manual-integration