### PR TITLE
Allow Netbox YAML configuration to be loaded from an environment variable

### DIFF
--- a/netbox/netbox.py
+++ b/netbox/netbox.py
@@ -368,7 +368,11 @@ class NetboxAsInventory(object):
 def main():
     # Script vars.
     args = cli_arguments()
-    config_data = open_yaml_file(args.config_file)
+    config_data_yaml = os.environ.get('NETBOX_CONFIG')
+    if config_data_yaml:
+        config_data = yaml.safe_load(config_data_yaml)
+    else:
+        config_data = open_yaml_file(args.config_file)
 
     # Netbox vars.
     netbox = NetboxAsInventory(args, config_data)


### PR DESCRIPTION
Although it's possible to use an environment variable to point Netbox to the configuration file location, I have a bit of a special use case. I am using this as a dynamic inventory script in Ansible AWX/Tower, however AWX itself runs inside a container with no persistent storage - making it very tricky to provide the configuration file.

With AWX/Tower however, it is possible to specify environment variables that are applied when a dynamic inventory script is run. This PR adds support for loading the YAML configuration for netbox-as-ansible-inventory from an environment variable (`NETBOX_CONFIG`). If that environment variable is missing, it will fall back to the current `open_yaml_file` function which loads from a file. 