### PR TITLE
Fixed ungrouped inventory host assignment. Resolves #19 and Fixes #32

### DIFF
--- a/netbox/netbox.py
+++ b/netbox/netbox.py
@@ -250,15 +250,19 @@ class NetboxAsInventory(object):
                 # The groups that will be used to group hosts in the inventory.
                 for group in groups_categories[category]:
                     # Try to get group value. If the section not found in netbox, this also will print error message.
-                    group_value = self._get_value_by_path(data_dict, [group, key_name])
-                    inventory_dict = self.add_host_to_group(server_name, group_value, inventory_dict)
+                    # If host not assigned to that section it will be assigned as "ungrouped"
+                    if data_dict:
+                        group_value = self._get_value_by_path(data_dict, [group, key_name])
 
-        # If no groups in "group_by" section, the host will go to catch-all group.
-        else:
-            if "no_group" not in inventory_dict:
-                inventory_dict.setdefault("no_group", [server_name])
-            else:
-                inventory_dict["no_group"].append(server_name)
+                        if group_value:
+                            inventory_dict = self.add_host_to_group(server_name, group_value, inventory_dict)
+                        # If no groups in "group_by" section, the host will go to catch-all group.
+                        else:
+                            if "ungrouped" not in inventory_dict:
+                                inventory_dict.setdefault("ungrouped", [server_name])
+                            else:
+                                inventory_dict["ungrouped"].append(server_name)
+
         return inventory_dict
 
     def get_host_vars(self, host_data, host_vars):

--- a/tests/test_netbox.py
+++ b/tests/test_netbox.py
@@ -410,15 +410,21 @@ class TestNetboxAsInventory(object):
          {"_meta": {"hostvars": {}}},
          fake_host),
         ({},
-         {"no_group": [], "_meta": {"hostvars": {}}},
+         {"ungrouped": [], "_meta": {"hostvars": {}}},
+         fake_host),
+        ({"default": []},
+         {"_meta": {"hostvars": {}}},
+         fake_host),
+        ({"default": ["platform"]},
+         {"_meta": {"hostvars": {}}},
          fake_host)
     ])
-    def test_add_host_to_inventory_with_no_group(self, groups_categories, inventory_dict, host_data):
+    def test_add_host_to_inventory_with_ungrouped(self, groups_categories, inventory_dict, host_data):
         """
         Test adding host to inventory with no group.
         """
         netbox_inventory.add_host_to_inventory(groups_categories, inventory_dict, host_data)
-        assert "fake_host01" in inventory_dict["no_group"]
+        assert "fake_host01" in inventory_dict["ungrouped"]
 
     @pytest.mark.parametrize("groups_categories, inventory_dict, host_data", [
         ({"default": ["arbitrary_group_name"]},


### PR DESCRIPTION
group called "ungrouped" is indeed a default group implicit in an Ansible inventory.

With this pull request I propose to
- change "no_group" to "ungrouped" (Resolves #19)
- fix the code to effectively assign to this group a device that is not part of any groups (Fixes #32)