### PR TITLE
Config context

### DIFF
--- a/netbox/netbox.py
+++ b/netbox/netbox.py
@@ -160,7 +160,7 @@ class NetboxAsInventory(object):
             A list of all hosts from netbox API including config context data.
             Identical data structure as get_hosts_list returns
         """
-        
+
         if not api_url:
             sys.exit("Please check API URL in script configuration file.")
 
@@ -174,7 +174,7 @@ class NetboxAsInventory(object):
         for device in source_dict:
             # Convert ID to string for each device
             id = str(device.get('id'))
-  
+
             # Gathers device data plus config-context
             context_data = requests.get(api_url + id, headers=api_url_headers)
 
@@ -195,7 +195,6 @@ class NetboxAsInventory(object):
         Returns:
             A list of all hosts from netbox API.
         """
-
         if not api_url:
             sys.exit("Please check API URL in script configuration file.")
 
@@ -220,7 +219,7 @@ class NetboxAsInventory(object):
 
             # Get api output data.
             api_output_data = api_output.json()
-  
+
             if isinstance(api_output_data, dict) and "results" in api_output_data:
                 hosts_list += api_output_data["results"]
                 api_url = api_output_data["next"]
@@ -290,6 +289,7 @@ class NetboxAsInventory(object):
                         # Try to get group value. If the section not found in netbox, this also will print error message.
                         if data_dict:
                             group_value = self._get_value_by_path(data_dict, [group, key_name])
+
                             if group_value:
                                 inventory_dict = self.add_host_to_group(server_name, group_value, inventory_dict)
                             # If any groups defined in "group_by" section, but host is not part of that group, it will go to catch-all group.
@@ -346,7 +346,6 @@ class NetboxAsInventory(object):
                     # This is because "custom_fields" has more than 1 type.
                     # Values inside "custom_fields" could be a key:value or a dict.
                     if 'context' in category:
-                    #if 'config_context' in var_name:
                         var_value = data_dict.get(var_data)
                     elif isinstance(data_dict.get(var_data), dict):
                         var_value = self._get_value_by_path(data_dict, [var_data, key_name], ignore_key_error=True)

--- a/netbox/netbox.py
+++ b/netbox/netbox.py
@@ -173,10 +173,10 @@ class NetboxAsInventory(object):
 
         for device in source_dict:
             # Convert ID to string for each device
-            id = str(device.get('id'))
+            device_id = str(device.get('id'))
 
             # Gathers device data plus config-context
-            context_data = requests.get(api_url + id, headers=api_url_headers)
+            context_data = requests.get(api_url + device_id, headers=api_url_headers)
 
             # Check that a request is 200 and not something else like 404, 401, 500 ... etc.
             context_data.raise_for_status()

--- a/netbox/netbox.py
+++ b/netbox/netbox.py
@@ -153,7 +153,7 @@ class NetboxAsInventory(object):
         return key_value
 
     @staticmethod
-    def get_config_context(source_dict, api_url, api_token=None):
+    def get_config_context(netbox_host_list, api_url, api_token=None):
         """Retrieves config_context data from each host obtained in get_hosts_list
 
         Returns:
@@ -171,7 +171,7 @@ class NetboxAsInventory(object):
 
         hosts_list = []
 
-        for device in source_dict:
+        for device in netbox_host_list:
             # Convert ID to string for each device
             device_id = str(device.get('id'))
 

--- a/netbox/netbox.py
+++ b/netbox/netbox.py
@@ -160,6 +160,7 @@ class NetboxAsInventory(object):
             A list of all hosts from netbox API including config context data.
             Identical data structure as get_hosts_list returns
         """
+
         if not api_url:
             sys.exit("Please check API URL in script configuration file.")
 
@@ -268,6 +269,7 @@ class NetboxAsInventory(object):
         Returns:
             The dict "inventory_dict" after adding the host to it.
         """
+
         server_name = host_data.get("name")
         categories_source = {
             "default": host_data,
@@ -324,6 +326,7 @@ class NetboxAsInventory(object):
         Returns:
             A dict has all vars are associated with the host.
         """
+
         host_vars_dict = dict()
         if host_vars:
             categories_source = {
@@ -332,6 +335,7 @@ class NetboxAsInventory(object):
                 "custom": host_data.get("custom_fields"),
                 "context": host_data
             }
+
             # Get host vars based on selected vars. (that should come from
             # script's config file)
             for category in host_vars:
@@ -368,6 +372,7 @@ class NetboxAsInventory(object):
         Returns:
             The dict "inventory_dict" after updating the host meta data.
         """
+
         if host_vars and not self.host:
             inventory_dict['_meta']['hostvars'].update({host_name: host_vars})
         elif host_vars and self.host:
@@ -380,6 +385,7 @@ class NetboxAsInventory(object):
         Returns:
             A dict has inventory with hosts and their vars.
         """
+
         inventory_dict = dict()
         netbox_hosts_list = self.get_hosts_list(self.api_url, self.api_token, self.host)
 
@@ -404,6 +410,7 @@ class NetboxAsInventory(object):
         Returns:
             It prints the inventory in JSON format if condition is true.
         """
+
         if self.host:
             result = inventory_dict.setdefault(self.host, {})
         elif self.list:

--- a/netbox/netbox.py
+++ b/netbox/netbox.py
@@ -160,7 +160,6 @@ class NetboxAsInventory(object):
             A list of all hosts from netbox API including config context data.
             Identical data structure as get_hosts_list returns
         """
-
         if not api_url:
             sys.exit("Please check API URL in script configuration file.")
 
@@ -182,7 +181,7 @@ class NetboxAsInventory(object):
             context_data.raise_for_status()
 
             # Convert api call data to json
-            context_output_data = json.loads(context_data.text)
+            context_output_data = context_data.json()
 
             # Append each device to hosts_list to be returned
             hosts_list.append(context_output_data)
@@ -269,7 +268,6 @@ class NetboxAsInventory(object):
         Returns:
             The dict "inventory_dict" after adding the host to it.
         """
-
         server_name = host_data.get("name")
         categories_source = {
             "default": host_data,
@@ -326,7 +324,6 @@ class NetboxAsInventory(object):
         Returns:
             A dict has all vars are associated with the host.
         """
-
         host_vars_dict = dict()
         if host_vars:
             categories_source = {
@@ -335,7 +332,6 @@ class NetboxAsInventory(object):
                 "custom": host_data.get("custom_fields"),
                 "context": host_data
             }
-
             # Get host vars based on selected vars. (that should come from
             # script's config file)
             for category in host_vars:
@@ -372,7 +368,6 @@ class NetboxAsInventory(object):
         Returns:
             The dict "inventory_dict" after updating the host meta data.
         """
-
         if host_vars and not self.host:
             inventory_dict['_meta']['hostvars'].update({host_name: host_vars})
         elif host_vars and self.host:
@@ -385,7 +380,6 @@ class NetboxAsInventory(object):
         Returns:
             A dict has inventory with hosts and their vars.
         """
-
         inventory_dict = dict()
         netbox_hosts_list = self.get_hosts_list(self.api_url, self.api_token, self.host)
 
@@ -410,7 +404,6 @@ class NetboxAsInventory(object):
         Returns:
             It prints the inventory in JSON format if condition is true.
         """
-
         if self.host:
             result = inventory_dict.setdefault(self.host, {})
         elif self.list:

--- a/netbox/netbox.py
+++ b/netbox/netbox.py
@@ -343,10 +343,10 @@ class NetboxAsInventory(object):
                 data_dict = categories_source[category]
 
                 for var_name, var_data in host_vars[category].items():
-                    # This is because "custom_fields" has more than 1 type.
-                    # Values inside "custom_fields" could be a key:value or a dict.
                     if 'context' in category:
                         var_value = data_dict.get(var_data)
+                    # This is because "custom_fields" has more than 1 type.
+                    # Values inside "custom_fields" could be a key:value or a dict.
                     elif isinstance(data_dict.get(var_data), dict):
                         var_value = self._get_value_by_path(data_dict, [var_data, key_name], ignore_key_error=True)
                     else:

--- a/netbox/netbox.py
+++ b/netbox/netbox.py
@@ -345,7 +345,8 @@ class NetboxAsInventory(object):
                 for var_name, var_data in host_vars[category].items():
                     # This is because "custom_fields" has more than 1 type.
                     # Values inside "custom_fields" could be a key:value or a dict.
-                    if 'config-context' in var_name:
+                    if 'context' in category:
+                    #if 'config_context' in var_name:
                         var_value = data_dict.get(var_data)
                     elif isinstance(data_dict.get(var_data), dict):
                         var_value = self._get_value_by_path(data_dict, [var_data, key_name], ignore_key_error=True)

--- a/tests/test_netbox.py
+++ b/tests/test_netbox.py
@@ -337,32 +337,32 @@ class TestNetboxAsInventory(object):
         (netbox_inventory.api_url)
     ])
     def test_get_config_context_all_hosts(self, netbox_api_all_hosts, api_url):
-      '''
-      Test gathering context_data from all devices.
-      '''
-      hosts_list = netbox_inventory.get_config_context(netbox_api_all_hosts, api_url)
-      assert isinstance(hosts_list[0]["config_context"], dict)
+        '''
+        Test gathering context_data from all devices.
+        '''
+        hosts_list = netbox_inventory.get_config_context(netbox_api_all_hosts, api_url)
+        assert isinstance(hosts_list[0]["config_context"], dict)
 
     @pytest.mark.parametrize("netbox_api_single_host, api_url", [
         (netbox_inventory.api_url)
     ])
     def test_get_config_context_single_host(self, netbox_api_single_host, api_url):
-      '''
-      Test gathering context_data from a single device.
-      '''
-      hosts_list = netbox_inventory.get_config_context(netbox_api_all_hosts, api_url)
-      assert isinstance(hosts_list["config_context"], dict)
+        '''
+        Test gathering context_data from a single device.
+        '''
+        hosts_list = netbox_inventory.get_config_context(netbox_api_single_host, api_url)
+        assert isinstance(hosts_list["config_context"], dict)
 
     @pytest.mark.parametrize("netbox_api_all_hosts, api_url, api_token", [
         (netbox_inventory.api_url, netbox_inventory.api_token)
     ])
-    def test_get_config_context_token(self, api_url, api_token):
+    def test_get_config_context_token(self, netbox_api_all_hosts, api_url, api_token):
         """
         Test get config context from API with token and make sure it returns a config context and its a dict.
         """
         with patch('requests.get', netbox_api_all_hosts):
             hosts_list = netbox_inventory.get_config_text(netbox_api_all_hosts, api_url, api_token)
-            assert isinstance(hosts_list["config_context"], dict)
+            assert isinstance(hosts_list[0]["config_context"], dict)
 
     @pytest.mark.parametrize("api_url", [
         (netbox_inventory.api_url)
@@ -529,6 +529,7 @@ class TestNetboxAsInventory(object):
             ansible_inventory = netbox_inventory.generate_inventory()
             assert "fake_host01" in ansible_inventory["_meta"]["hostvars"]
             assert isinstance(ansible_inventory["_meta"]["hostvars"]["fake_host02"], dict)
+            assert isinstance(ansible_inventory["_meta"]["hostvars"]["fake_host02"]["config_context"], dict)
 
     @pytest.mark.parametrize("inventory_dict", [
         {

--- a/tests/test_netbox.py
+++ b/tests/test_netbox.py
@@ -77,14 +77,17 @@ netbox_api_output = json.loads('''
   "count": 2,
   "next": null,
   "previous": null,
-  "results": [
+  "results": 
+  [    
     {
       "id": 1,
       "name": "fake_host01",
       "display_name": "Fake Host",
-      "device_type": {
+      "device_type": 
+      {
         "id": 1,
-        "manufacturer": {
+        "manufacturer": 
+        {
           "id": 8,
           "name": "Fake Manufacturer",
           "slug": "fake_manufacturer"
@@ -92,7 +95,8 @@ netbox_api_output = json.loads('''
         "model": "all",
         "slug": "all"
       },
-      "device_role": {
+      "device_role": 
+      {
         "id": 8,
         "name": "Fake Server",
         "slug": "fake_server"
@@ -101,7 +105,8 @@ netbox_api_output = json.loads('''
       "platform": null,
       "serial": "",
       "asset_tag": "fake_tag",
-      "rack": {
+      "rack": 
+      {
         "id": 1,
         "name": "fake_rack01",
         "facility_id": null,
@@ -111,39 +116,47 @@ netbox_api_output = json.loads('''
       "face": null,
       "parent_device": null,
       "status": true,
-      "primary_ip": {
+      "primary_ip": 
+      {
         "id": 1,
         "family": 4,
         "address": "192.168.0.2/32"
       },
-      "primary_ip4": {
+      "primary_ip4": 
+      {
         "id": 1,
         "family": 4,
         "address": "192.168.0.2/32"
       },
       "primary_ip6": null,
       "comments": "",
-      "custom_fields": {
+      "custom_fields": 
+      {
         "label": "Web",
-        "env": {
+        "env": 
+        {
           "id": 1,
           "value": "Prod"
         }
       },
-      "config_context": {
-        "ntp-servers": {
-          "ntp1": "192.168.1.1"
+      "config_context": 
+      {
+        "ntp-servers": 
+        {
+          "ntp1": "192.168.1.1",
           "ntp2": "192.168.1.2"
-          }
+        }
       }
-    },
+    },    
     {
       "id": 2,
       "name": "fake_host02",
       "display_name": "fake_host02",
-      "device_type": {
+      "device_type": 
+      {
         "id": 1,
-        "manufacturer": {
+        "manufacturer": 
+        {
           "id": 8,
           "name": "Super Micro",
           "slug": "super-micro"
@@ -151,7 +164,8 @@ netbox_api_output = json.loads('''
         "model": "all",
         "slug": "all"
       },
-      "device_role": {
+      "device_role": 
+      {
         "id": 8,
         "name": "Server",
         "slug": "server"
@@ -160,7 +174,8 @@ netbox_api_output = json.loads('''
       "platform": null,
       "serial": "",
       "asset_tag": "xtag",
-      "rack": {
+      "rack": 
+      {
         "id": 1,
         "name": "fake_rack01",
         "facility_id": null,
@@ -174,16 +189,20 @@ netbox_api_output = json.loads('''
       "primary_ip4": null,
       "primary_ip6": null,
       "comments": "",
-      "custom_fields": {
+      "custom_fields": 
+      {
         "label": "DB",
-        "env": {
+        "env": 
+        {
           "id": 1,
           "value": "Prod"
         }
       },
-      "config_context": {
-        "ntp-servers": {
-          "ntp1": "192.168.1.1"
+      "config_context": 
+      {
+        "ntp-servers": 
+        {
+          "ntp1": "192.168.1.1",
           "ntp2": "192.168.1.2"
         }
       }

--- a/tests/test_netbox.py
+++ b/tests/test_netbox.py
@@ -358,11 +358,11 @@ class TestNetboxAsInventory(object):
         '''
         Test gathering context_data from all devices.
         '''
-        #with patch('requests.get', netbox_api_all_hosts):
-        hosts_list = netbox_inventory.get_hosts_list(api_url)
-        context_data = netbox_inventory.get_config_context(hosts_list, api_url)
-        assert isinstance(hosts_list, list)
-        assert isinstance(context_data[0]["config_context"], dict)
+        with patch('requests.get', netbox_api_all_hosts):
+            hosts_list = netbox_inventory.get_hosts_list(api_url)
+            context_data = netbox_inventory.get_config_context(hosts_list, api_url)
+            assert isinstance(hosts_list, list)
+            assert isinstance(context_data[0]["config_context"], dict)
 
     @pytest.mark.parametrize("api_url, api_token, host_name", [
         (netbox_inventory_single.api_url, netbox_inventory_single.api_token, netbox_inventory_single.host)

--- a/tests/test_netbox.py
+++ b/tests/test_netbox.py
@@ -157,7 +157,7 @@ netbox_api_output = json.loads('''
         "manufacturer":
         {
           "id": 8,
-          "name": "Super Micro"
+          "name": "Super Micro",
           "slug": "super-micro"
         },
         "model": "all",

--- a/tests/test_netbox.py
+++ b/tests/test_netbox.py
@@ -352,7 +352,7 @@ class TestNetboxAsInventory(object):
         assert empty_config_error
 
     @pytest.mark.parametrize("netbox_api_all_hosts, api_url", [
-        (netbox_api_all_hosts, netbox_inventory.api_url)
+        (netbox_inventory.api_url)
     ])
     def test_get_config_context_all_hosts(self, api_url):
         '''
@@ -364,19 +364,19 @@ class TestNetboxAsInventory(object):
             assert isinstance(context_data[0]["config_context"], dict)
 
     @pytest.mark.parametrize("netbox_api_single_host, api_url", [
-        (netbox_api_single_host, netbox_inventory.api_url)
+        (netbox_inventory_single.api_url, netbox_inventory_single.api_token, netbox_inventory_single.host)
     ])
     def test_get_config_context_single_host(self, api_url, api_token, host_name):
         '''
         Test gathering context_data from a single device.
         '''
-        with patch('requests.get', netbox_api_all_hosts):
+        with patch('requests.get', netbox_api_single_host):
             hosts_list = netbox_inventory.get_hosts_list(api_url, api_token, host_name)
             context_data = netbox_inventory.get_config_context(hosts_list, api_url)
             assert isinstance(context_data[0]["config_context"], dict)
 
     @pytest.mark.parametrize("netbox_api_all_hosts, api_url, api_token", [
-        (netbox_api_all_hosts, netbox_inventory.api_url, netbox_inventory.api_token)
+        (netbox_inventory.api_url, netbox_inventory.api_token)
     ])
     def test_get_config_context_token(self, api_url, api_token):
         """

--- a/tests/test_netbox.py
+++ b/tests/test_netbox.py
@@ -77,7 +77,7 @@ netbox_api_output = json.loads('''
   "count": 2,
   "next": null,
   "previous": null,
-  "results": [    
+  "results": [
     {
       "id": 1,
       "name": "fake_host01",
@@ -92,7 +92,7 @@ netbox_api_output = json.loads('''
         "model": "all",
         "slug": "all"
       },
-      "device_role": 
+      "device_role":
       {
         "id": 8,
         "name": "Fake Server",
@@ -102,7 +102,7 @@ netbox_api_output = json.loads('''
       "platform": null,
       "serial": "",
       "asset_tag": "fake_tag",
-      "rack": 
+      "rack":
       {
         "id": 1,
         "name": "fake_rack01",
@@ -113,7 +113,7 @@ netbox_api_output = json.loads('''
       "face": null,
       "parent_device": null,
       "status": true,
-      "primary_ip": 
+      "primary_ip":
       {
         "id": 1,
         "family": 4,
@@ -127,32 +127,32 @@ netbox_api_output = json.loads('''
       },
       "primary_ip6": null,
       "comments": "",
-      "custom_fields": 
+      "custom_fields":
       {
         "label": "Web",
-        "env": 
+        "env":
         {
           "id": 1,
           "value": "Prod"
         }
       },
-      "config_context": 
+      "config_context":
       {
-        "ntp-servers": 
+        "ntp-servers":
         {
           "ntp1": "192.168.1.1",
           "ntp2": "192.168.1.2"
         }
       }
-    },    
+    },
     {
       "id": 2,
       "name": "fake_host02",
       "display_name": "fake_host02",
-      "device_type": 
+      "device_type":
       {
         "id": 1,
-        "manufacturer": 
+        "manufacturer":
         {
           "id": 8,
           "name": "Super Micro"
@@ -161,7 +161,7 @@ netbox_api_output = json.loads('''
         "model": "all",
         "slug": "all"
       },
-      "device_role": 
+      "device_role":
       {
         "id": 8,
         "name": "Server",
@@ -171,7 +171,7 @@ netbox_api_output = json.loads('''
       "platform": null,
       "serial": "",
       "asset_tag": "xtag",
-      "rack": 
+      "rack":
       {
         "id": 1,
         "name": "fake_rack01",
@@ -186,18 +186,18 @@ netbox_api_output = json.loads('''
       "primary_ip4": null,
       "primary_ip6": null,
       "comments": "",
-      "custom_fields": 
+      "custom_fields":
       {
         "label": "DB",
-        "env": 
+        "env":
         {
           "id": 1,
           "value": "Prod"
         }
       },
-      "config_context": 
+      "config_context":
       {
-        "ntp-servers": 
+        "ntp-servers":
         {
           "ntp1": "192.168.1.1",
           "ntp2": "192.168.1.2"

--- a/tests/test_netbox.py
+++ b/tests/test_netbox.py
@@ -354,33 +354,35 @@ class TestNetboxAsInventory(object):
     @pytest.mark.parametrize("netbox_api_all_hosts, api_url", [
         (netbox_api_all_hosts, netbox_inventory.api_url)
     ])
-    def test_get_config_context_all_hosts(self, netbox_api_all_hosts, api_url):
+    def test_get_config_context_all_hosts(self, api_url):
         '''
         Test gathering context_data from all devices.
         '''
-        hosts_list = netbox_inventory.get_config_context(netbox_api_all_hosts, api_url)
-        assert isinstance(hosts_list[0]["config_context"], dict)
+        hosts_list = netbox_inventory.get_hosts_list(api_url)
+        context_data = netbox_inventory.get_config_context(hosts_list, api_url)
+        assert isinstance(context_data[0]["config_context"], dict)
 
     @pytest.mark.parametrize("netbox_api_single_host, api_url", [
         (netbox_api_single_host, netbox_inventory.api_url)
     ])
-    def test_get_config_context_single_host(self, netbox_api_single_host, api_url):
+    def test_get_config_context_single_host(self, api_url, api_token, host_name):
         '''
         Test gathering context_data from a single device.
         '''
-        hosts_list = netbox_inventory.get_config_context(netbox_api_single_host, api_url)
-        assert isinstance(hosts_list[0]["config_context"], dict)
+        hosts_list = netbox_inventory.get_hosts_list(api_url, api_token, host_name)
+        context_data = netbox_inventory.get_config_context(hosts_list, api_url)
+        assert isinstance(context_data[0]["config_context"], dict)
 
     @pytest.mark.parametrize("netbox_api_all_hosts, api_url, api_token", [
         (netbox_api_all_hosts, netbox_inventory.api_url, netbox_inventory.api_token)
     ])
-    def test_get_config_context_token(self, netbox_api_all_hosts, api_url, api_token):
+    def test_get_config_context_token(self, api_url, api_token):
         """
         Test get config context from API with token and make sure it returns a config context and its a dict.
         """
-        with patch('requests.get', netbox_api_all_hosts):
-            hosts_list = netbox_inventory.get_config_text(netbox_api_all_hosts, api_url, api_token)
-            assert isinstance(hosts_list[0]["config_context"], dict)
+        hosts_list = netbox_inventory.get_hosts_list(api_url)
+        context_data = netbox_inventory.get_config_context(hosts_list, api_url, api_token)
+        assert isinstance(context_data[0]["config_context"], dict)
 
     @pytest.mark.parametrize("api_url", [
         (netbox_inventory.api_url)

--- a/tests/test_netbox.py
+++ b/tests/test_netbox.py
@@ -82,9 +82,11 @@ netbox_api_output = json.loads('''
       "id": 1,
       "name": "fake_host01",
       "display_name": "Fake Host",
-      "device_type": {
+      "device_type":
+      {
         "id": 1,
-        "manufacturer": {
+        "manufacturer":
+        {
           "id": 8,
           "name": "Fake Manufacturer",
           "slug": "fake_manufacturer"
@@ -119,7 +121,7 @@ netbox_api_output = json.loads('''
         "family": 4,
         "address": "192.168.0.2/32"
       },
-      "primary_ip4": 
+      "primary_ip4":
       {
         "id": 1,
         "family": 4,

--- a/tests/test_netbox.py
+++ b/tests/test_netbox.py
@@ -378,7 +378,7 @@ class TestNetboxAsInventory(object):
                 specific_host=host_name)
             context_data = netbox_inventory.get_config_context(hosts_list, api_url)
             assert isinstance(hosts_list, list)
-            assert isinstance(context_data[0]["config_context"], dict)
+            assert isinstance(context_data["config_context"], dict)
 
     @pytest.mark.parametrize("api_url, api_token", [
         (netbox_inventory.api_url, netbox_inventory.api_token)

--- a/tests/test_netbox.py
+++ b/tests/test_netbox.py
@@ -359,10 +359,10 @@ class TestNetboxAsInventory(object):
         Test gathering context_data from all devices.
         '''
         #with patch('requests.get', netbox_api_all_hosts):
-            hosts_list = netbox_inventory.get_hosts_list(api_url)
-            context_data = netbox_inventory.get_config_context(hosts_list, api_url)
-            assert isinstance(hosts_list, list)
-            assert isinstance(context_data[0]["config_context"], dict)
+        hosts_list = netbox_inventory.get_hosts_list(api_url)
+        context_data = netbox_inventory.get_config_context(hosts_list, api_url)
+        assert isinstance(hosts_list, list)
+        assert isinstance(context_data[0]["config_context"], dict)
 
     @pytest.mark.parametrize("api_url, api_token, host_name", [
         (netbox_inventory_single.api_url, netbox_inventory_single.api_token, netbox_inventory_single.host)

--- a/tests/test_netbox.py
+++ b/tests/test_netbox.py
@@ -358,9 +358,10 @@ class TestNetboxAsInventory(object):
         '''
         Test gathering context_data from all devices.
         '''
-        with patch('requests.get', netbox_api_all_hosts):
+        #with patch('requests.get', netbox_api_all_hosts):
             hosts_list = netbox_inventory.get_hosts_list(api_url)
             context_data = netbox_inventory.get_config_context(hosts_list, api_url)
+            assert isinstance(hosts_list, list)
             assert isinstance(context_data[0]["config_context"], dict)
 
     @pytest.mark.parametrize("api_url, api_token, host_name", [
@@ -371,11 +372,12 @@ class TestNetboxAsInventory(object):
         Test gathering context_data from a single device.
         '''
         with patch('requests.get', netbox_api_single_host):
-            host_data = netbox_inventory_single.get_hosts_list(
+            hosts_list = netbox_inventory_single.get_hosts_list(
                 api_url,
                 api_token,
                 specific_host=host_name)
             context_data = netbox_inventory.get_config_context(hosts_list, api_url)
+            assert isinstance(hosts_list, list)
             assert isinstance(context_data[0]["config_context"], dict)
 
     @pytest.mark.parametrize("api_url, api_token", [
@@ -388,6 +390,7 @@ class TestNetboxAsInventory(object):
         with patch('requests.get', netbox_api_all_hosts):
             hosts_list = netbox_inventory.get_hosts_list(api_url, api_token)
             context_data = netbox_inventory.get_config_context(hosts_list, api_url, api_token)
+            assert isinstance(hosts_list, list)
             assert isinstance(context_data[0]["config_context"], dict)
 
     @pytest.mark.parametrize("api_url", [

--- a/tests/test_netbox.py
+++ b/tests/test_netbox.py
@@ -351,7 +351,7 @@ class TestNetboxAsInventory(object):
             netbox.NetboxAsInventory(args, config)
         assert empty_config_error
 
-    @pytest.mark.parametrize("netbox_api_all_hosts, api_url", [
+    @pytest.mark.parametrize("api_url", [
         (netbox_inventory.api_url)
     ])
     def test_get_config_context_all_hosts(self, api_url):
@@ -363,7 +363,7 @@ class TestNetboxAsInventory(object):
             context_data = netbox_inventory.get_config_context(hosts_list, api_url)
             assert isinstance(context_data[0]["config_context"], dict)
 
-    @pytest.mark.parametrize("netbox_api_single_host, api_url", [
+    @pytest.mark.parametrize("api_url, api_token, host_name", [
         (netbox_inventory_single.api_url, netbox_inventory_single.api_token, netbox_inventory_single.host)
     ])
     def test_get_config_context_single_host(self, api_url, api_token, host_name):
@@ -371,11 +371,14 @@ class TestNetboxAsInventory(object):
         Test gathering context_data from a single device.
         '''
         with patch('requests.get', netbox_api_single_host):
-            hosts_list = netbox_inventory.get_hosts_list(api_url, api_token, host_name)
+            host_data = netbox_inventory_single.get_hosts_list(
+                api_url,
+                api_token,
+                specific_host=host_name)
             context_data = netbox_inventory.get_config_context(hosts_list, api_url)
             assert isinstance(context_data[0]["config_context"], dict)
 
-    @pytest.mark.parametrize("netbox_api_all_hosts, api_url, api_token", [
+    @pytest.mark.parametrize("api_url, api_token", [
         (netbox_inventory.api_url, netbox_inventory.api_token)
     ])
     def test_get_config_context_token(self, api_url, api_token):
@@ -383,7 +386,7 @@ class TestNetboxAsInventory(object):
         Test get config context from API with token and make sure it returns a config context and its a dict.
         """
         with patch('requests.get', netbox_api_all_hosts):
-            hosts_list = netbox_inventory.get_hosts_list(api_url)
+            hosts_list = netbox_inventory.get_hosts_list(api_url, api_token)
             context_data = netbox_inventory.get_config_context(hosts_list, api_url, api_token)
             assert isinstance(context_data[0]["config_context"], dict)
 

--- a/tests/test_netbox.py
+++ b/tests/test_netbox.py
@@ -77,17 +77,14 @@ netbox_api_output = json.loads('''
   "count": 2,
   "next": null,
   "previous": null,
-  "results": 
-  [    
+  "results": [    
     {
       "id": 1,
       "name": "fake_host01",
       "display_name": "Fake Host",
-      "device_type": 
-      {
+      "device_type": {
         "id": 1,
-        "manufacturer": 
-        {
+        "manufacturer": {
           "id": 8,
           "name": "Fake Manufacturer",
           "slug": "fake_manufacturer"
@@ -158,7 +155,7 @@ netbox_api_output = json.loads('''
         "manufacturer": 
         {
           "id": 8,
-          "name": "Super Micro",
+          "name": "Super Micro"
           "slug": "super-micro"
         },
         "model": "all",
@@ -353,7 +350,7 @@ class TestNetboxAsInventory(object):
         assert empty_config_error
 
     @pytest.mark.parametrize("netbox_api_all_hosts, api_url", [
-        (netbox_inventory.api_url)
+        (netbox_api_all_hosts, netbox_inventory.api_url)
     ])
     def test_get_config_context_all_hosts(self, netbox_api_all_hosts, api_url):
         '''
@@ -363,17 +360,17 @@ class TestNetboxAsInventory(object):
         assert isinstance(hosts_list[0]["config_context"], dict)
 
     @pytest.mark.parametrize("netbox_api_single_host, api_url", [
-        (netbox_inventory.api_url)
+        (netbox_api_single_host, netbox_inventory.api_url)
     ])
     def test_get_config_context_single_host(self, netbox_api_single_host, api_url):
         '''
         Test gathering context_data from a single device.
         '''
         hosts_list = netbox_inventory.get_config_context(netbox_api_single_host, api_url)
-        assert isinstance(hosts_list["config_context"], dict)
+        assert isinstance(hosts_list[0]["config_context"], dict)
 
     @pytest.mark.parametrize("netbox_api_all_hosts, api_url, api_token", [
-        (netbox_inventory.api_url, netbox_inventory.api_token)
+        (netbox_api_all_hosts, netbox_inventory.api_url, netbox_inventory.api_token)
     ])
     def test_get_config_context_token(self, netbox_api_all_hosts, api_url, api_token):
         """

--- a/tests/test_netbox.py
+++ b/tests/test_netbox.py
@@ -358,9 +358,10 @@ class TestNetboxAsInventory(object):
         '''
         Test gathering context_data from all devices.
         '''
-        hosts_list = netbox_inventory.get_hosts_list(api_url)
-        context_data = netbox_inventory.get_config_context(hosts_list, api_url)
-        assert isinstance(context_data[0]["config_context"], dict)
+        with patch('requests.get', netbox_api_all_hosts):
+            hosts_list = netbox_inventory.get_hosts_list(api_url)
+            context_data = netbox_inventory.get_config_context(hosts_list, api_url)
+            assert isinstance(context_data[0]["config_context"], dict)
 
     @pytest.mark.parametrize("netbox_api_single_host, api_url", [
         (netbox_api_single_host, netbox_inventory.api_url)
@@ -369,9 +370,10 @@ class TestNetboxAsInventory(object):
         '''
         Test gathering context_data from a single device.
         '''
-        hosts_list = netbox_inventory.get_hosts_list(api_url, api_token, host_name)
-        context_data = netbox_inventory.get_config_context(hosts_list, api_url)
-        assert isinstance(context_data[0]["config_context"], dict)
+        with patch('requests.get', netbox_api_all_hosts):
+            hosts_list = netbox_inventory.get_hosts_list(api_url, api_token, host_name)
+            context_data = netbox_inventory.get_config_context(hosts_list, api_url)
+            assert isinstance(context_data[0]["config_context"], dict)
 
     @pytest.mark.parametrize("netbox_api_all_hosts, api_url, api_token", [
         (netbox_api_all_hosts, netbox_inventory.api_url, netbox_inventory.api_token)
@@ -380,9 +382,10 @@ class TestNetboxAsInventory(object):
         """
         Test get config context from API with token and make sure it returns a config context and its a dict.
         """
-        hosts_list = netbox_inventory.get_hosts_list(api_url)
-        context_data = netbox_inventory.get_config_context(hosts_list, api_url, api_token)
-        assert isinstance(context_data[0]["config_context"], dict)
+        with patch('requests.get', netbox_api_all_hosts):
+            hosts_list = netbox_inventory.get_hosts_list(api_url)
+            context_data = netbox_inventory.get_config_context(hosts_list, api_url, api_token)
+            assert isinstance(context_data[0]["config_context"], dict)
 
     @pytest.mark.parametrize("api_url", [
         (netbox_inventory.api_url)


### PR DESCRIPTION
Since config contexts are new as of 2.4 I figured it'd be nice to be able to use those as host vars.

I'm not sure if this implementation is the best way so additional tweaks may be needed.

### Overview

- Add `context:` under `hosts_vars` in netbox.yml

`hosts_vars:
    context:
        variable_name: config_context
`

- Once `context:` is configured under `hosts_vars` it will gather the context data for a single device or all devices

### Sample data
`./netbox.py --host switch2
{"ansible_ssh_host": "192.168.1.1", "serial": "awadawd21254", "asset-tag": "1001", "config_context": {"ntp2": "192.168.1.2", "ntp1": "192.168.1.1"}}
`


`./netbox.py --list
{"_meta": {"hostvars": {"switch1": {"serial": "cisco-serial", "asset_tag": "1234", "config_context": {"radius": {"radius03": "10.0.0.3", "radius02": "10.0.0.2", "radius01": "10.0.0.1"}, "tacacs": {"acs03": "10.0.0.3", "acs02": "10.0.0.2", "acs01": "10.0.0.1"}, "ntp-servers": {"ntp2": "192.168.1.2", "ntp1": "192.168.1.1"} "10": ["permit 10.0.0.0 0.0.0.255", "permit 172.16.0.0 0.0.255.255"]}}
"switch2": {"ansible_ssh_host": "192.168.1.1", "serial": "awadawd21254", "asset-tag": "1001", "config_context": {"ntp2": "192.168.1.2", "ntp1": "192.168.1.1"}}, "group1": ["switch1"], "group2": ["switch2"]}`


