### PR TITLE
Config context addition

### DIFF
--- a/netbox/netbox.py
+++ b/netbox/netbox.py
@@ -88,7 +88,8 @@ class NetboxAsInventory(object):
             "default": "name",
             "general": "name",
             "custom": "value",
-            "ip": "address"
+            "ip": "address",
+            "context": "value"
         }
 
     def _get_value_by_path(self, source_dict, key_path,
@@ -152,13 +153,49 @@ class NetboxAsInventory(object):
         return key_value
 
     @staticmethod
+    def get_config_context(netbox_host_list, api_url, api_token=None):
+        """Retrieves config_context data from each host obtained in get_hosts_list
+
+        Returns:
+            A list of all hosts from netbox API including config context data.
+            Identical data structure as get_hosts_list returns
+        """
+
+        if not api_url:
+            sys.exit("Please check API URL in script configuration file.")
+
+        api_url_headers = {}
+
+        if api_token:
+            api_url_headers.update({"Authorization": "Token %s" % api_token})
+
+        hosts_list = []
+
+        for device in netbox_host_list:
+            # Convert ID to string for each device
+            device_id = str(device.get('id'))
+
+            # Gathers device data plus config-context
+            context_data = requests.get(api_url + device_id, headers=api_url_headers)
+
+            # Check that a request is 200 and not something else like 404, 401, 500 ... etc.
+            context_data.raise_for_status()
+
+            # Convert api call data to json
+            context_output_data = context_data.json()
+
+            # Append each device to hosts_list to be returned
+            hosts_list.append(context_output_data)
+
+        return hosts_list
+
+    @staticmethod
     def get_hosts_list(api_url, api_token=None, specific_host=None):
         """Retrieves hosts list from netbox API.
 
         Returns:
             A list of all hosts from netbox API.
         """
-
         if not api_url:
             sys.exit("Please check API URL in script configuration file.")
 
@@ -296,7 +333,8 @@ class NetboxAsInventory(object):
             categories_source = {
                 "ip": host_data,
                 "general": host_data,
-                "custom": host_data.get("custom_fields")
+                "custom": host_data.get("custom_fields"),
+                "context": host_data
             }
 
             # Get host vars based on selected vars. (that should come from
@@ -306,13 +344,14 @@ class NetboxAsInventory(object):
                 data_dict = categories_source[category]
 
                 for var_name, var_data in host_vars[category].items():
+                    if 'context' in category:
+                        var_value = data_dict.get(var_data)
                     # This is because "custom_fields" has more than 1 type.
                     # Values inside "custom_fields" could be a key:value or a dict.
-                    if isinstance(data_dict.get(var_data), dict):
+                    elif isinstance(data_dict.get(var_data), dict):
                         var_value = self._get_value_by_path(data_dict, [var_data, key_name], ignore_key_error=True)
                     else:
                         var_value = data_dict.get(var_data)
-
                     if var_value is not None:
                         # Remove CIDR from IP address.
                         if "ip" in host_vars and var_data in host_vars["ip"].values():
@@ -350,6 +389,9 @@ class NetboxAsInventory(object):
 
         inventory_dict = dict()
         netbox_hosts_list = self.get_hosts_list(self.api_url, self.api_token, self.host)
+
+        if 'context' in self.hosts_vars:
+            netbox_hosts_list = self.get_config_context(netbox_hosts_list, self.api_url, self.api_token)
 
         if netbox_hosts_list:
             inventory_dict.update({"_meta": {"hostvars": {}}})

--- a/tests/test_netbox.py
+++ b/tests/test_netbox.py
@@ -209,7 +209,7 @@ netbox_api_output = json.loads('''
 }
 ''')
 
-netbox_api_config_context_output = json.loads('''
+netbox_api_config_context_fake_host01 = json.loads('''
 {
   "id": 1,
   "name": "fake_host01",
@@ -271,6 +271,60 @@ netbox_api_config_context_output = json.loads('''
 }
 ''')
 
+netbox_api_config_context_fake_host02 = json.loads('''
+{
+  "id": 2,
+  "name": "fake_host02",
+  "display_name": "fake_host02",
+  "device_type": {
+    "id": 1,
+    "manufacturer": {
+      "id": 8,
+      "name": "Super Micro",
+      "slug": "super-micro"
+    },
+      "model": "all",
+    "slug": "all"
+  },
+  "device_role": {
+    "id": 8,
+    "name": "Server",
+    "slug": "server"
+  },
+  "tenant": null,
+  "platform": null,
+  "serial": "",
+  "asset_tag": "xtag",
+  "rack": {
+    "id": 1,
+    "name": "fake_rack01",
+    "facility_id": null,
+    "display_name": "Fake Host 02"
+  },
+  "position": null,
+  "face": null,
+  "parent_device": null,
+  "status": true,
+  "primary_ip": null,
+  "primary_ip4": null,
+  "primary_ip6": null,
+  "comments": "",
+  "custom_fields": {
+    "label": "DB",
+    "env": {
+      "id": 1,
+      "value": "Prod"
+    }
+  },
+  "config_context": {
+  "ntp_servers": {
+    "ntp1": "192.168.1.1",
+    "ntp2": "192.168.1.2"
+    }
+  }
+}
+''')
+
 
 # Fake Netbox API response.
 def mock_response(json_payload):
@@ -278,6 +332,7 @@ def mock_response(json_payload):
     response.status_code = 200
     response.json = MagicMock(return_value=json_payload)
     return MagicMock(return_value=response)
+
 
 # Set API output with a single host.
 netbox_api_output_single = netbox_api_output.copy()
@@ -290,11 +345,11 @@ netbox_output_config_context = netbox_api_output["results"]
 # Fake API output.
 netbox_api_all_hosts = mock_response(netbox_api_output)
 netbox_api_single_host = mock_response(netbox_api_output_single)
-netbox_api_config_context = mock_response(netbox_api_config_context_output)
+netbox_api_config_context_fake_host01 = mock_response(netbox_api_config_context_fake_host01)
+netbox_api_config_context_fake_host02 = mock_response(netbox_api_config_context_fake_host02)
 
 # Fake hosts list for config context tests
-netbox_host_list = []
-netbox_host_list.append(netbox_api_output["results"][0])
+netbox_host_list = netbox_api_output["results"]
 
 
 #
@@ -303,6 +358,7 @@ class Args(object):
     config_file = "netbox.yml"
     host = None
     list = True
+
 
 netbox_inventory = netbox.NetboxAsInventory(Args, netbox_config_data)
 Args.list = False
@@ -422,13 +478,16 @@ class TestNetboxAsInventory(object):
     @pytest.mark.parametrize("netbox_host_list, api_url", [
         (netbox_host_list, netbox_inventory.api_url)
     ])
+    @patch('requests.get', netbox_api_config_context_fake_host02)
+    @patch('requests.get', netbox_api_config_context_fake_host01)
     def test_get_config_context(self, netbox_host_list, api_url):
         """
         Test get config context without token and makes sure it returns a config_context as dict
         """
-        with patch('requests.get', netbox_api_config_context):
-            config_context_output = netbox_inventory_config_context.get_config_context(netbox_host_list, api_url)
-            assert isinstance(config_context_output[0]['config_context'], dict)
+        config_context_output = netbox_inventory_config_context.get_config_context(netbox_host_list, api_url)
+        assert isinstance(config_context_output, list)
+        assert isinstance(config_context_output[0]['config_context'], dict)
+        assert isinstance(config_context_output[1]['config_context'], dict)
 
     @pytest.mark.parametrize("api_url", [
         (netbox_inventory.api_url)


### PR DESCRIPTION
### Overview
I'm proposing adding config context to this script since this is a new addition to Netbox 2.4. This will allow users to add `Context:` to the netbox.yml file to be able to pull config contexts from devices. This does rely on information gather from the get_host_list() function as we have to iterate over it and use the obtained devices ID's to pull the config contexts for the devices.

### Netbox.yml format
```
hosts_vars:
    context:
        variable_name: config_context
```
Please let me know if I can make any improvements to the code as I'm new to Python and I'm sure the code can be improved on. I also created a test for the function, but may need help further with the test and validating that the test is setup as it should be.