### PR TITLE
Fix pip issue and remove py2.6 from ci pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
   - "3.5"
 cache: pip

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ def open_file(file_name, splitlines=False):
 
     return file_output
 
+
 # Get vars from project files.
 version = open_file('VERSION')
 long_description = open_file('README.rst')
@@ -92,12 +93,14 @@ class Requirements(Command):
         pass
 
     def run(self):
-        import pip
-
         # Install requirements via pip.
-        pip.main(['install', '.'])
+        cmd = ['pip', 'install', '-r', 'requirements.txt']
+
         if self.tests_requirement:
-            pip.main(['install', '.[tests]'])
+            cmd += ['-r', 'tests/requirements.txt']
+
+        print(' '.join(cmd))
+        subprocess.check_call(cmd)
 
 setup(
     name='ansible-netbox-inventory',


### PR DESCRIPTION
The pip package has moved `main` function to internals, so instead importing pip as a package in step.py, will be used from command line.

Also py2.6 has been removed from ci.