### PR TITLE
inventory index generation

### DIFF
--- a/netbox/netbox.py
+++ b/netbox/netbox.py
@@ -82,6 +82,7 @@ class NetboxAsInventory(object):
         self.api_token = self._config(["main", "api_token"], default="", optional=True)
         self.group_by = self._config(["group_by"], default={})
         self.hosts_vars = self._config(["hosts_vars"], default={})
+        self.inv_host_key_fields = self._config(["host_key"], default=['name'])
 
         # Get value based on key.
         self.key_map = {
@@ -218,7 +219,8 @@ class NetboxAsInventory(object):
                 inventory_dict[group_value].append(server_name)
         return inventory_dict
 
-    def add_host_to_inventory(self, groups_categories, inventory_dict, host_data):
+    def add_host_to_inventory(self, groups_categories, server_name,
+                              inventory_dict, host_data):
         """Add a host to its groups.
 
         It checks if host in the groups and adds the host to these groups.
@@ -234,7 +236,6 @@ class NetboxAsInventory(object):
             The dict "inventory_dict" after adding the host to it.
         """
 
-        server_name = host_data.get("name")
         categories_source = {
             "default": host_data,
             "custom": host_data.get("custom_fields")
@@ -341,6 +342,22 @@ class NetboxAsInventory(object):
             inventory_dict.update({host_name: host_vars})
         return inventory_dict
 
+    def _generate_inventory_host_key(self, netbox_host_context):
+        """Generate Ansible dynamic inventory host name from netbox
+           Netbox fields.
+
+           Returns:
+            String of netbox fields elected for invetory index.
+        """
+        seperator = "_"
+        eventual_host_name = []
+        for netbox_field in self.inv_host_key_fields:
+            field_value = netbox_host_context.get(netbox_field)
+            if field_value:
+                eventual_host_name.append(field_value)
+
+        return seperator.join(eventual_host_name)
+
     def generate_inventory(self):
         """Generate Ansible dynamic inventory.
 
@@ -350,12 +367,12 @@ class NetboxAsInventory(object):
 
         inventory_dict = dict()
         netbox_hosts_list = self.get_hosts_list(self.api_url, self.api_token, self.host)
-
         if netbox_hosts_list:
             inventory_dict.update({"_meta": {"hostvars": {}}})
             for current_host in netbox_hosts_list:
-                server_name = current_host.get("name")
-                self.add_host_to_inventory(self.group_by, inventory_dict, current_host)
+                server_name = self._generate_inventory_host_key(current_host)
+                self.add_host_to_inventory(self.group_by, server_name,
+                                           inventory_dict, current_host)
                 host_vars = self.get_host_vars(current_host, self.hosts_vars)
                 inventory_dict = self.update_host_meta_vars(inventory_dict, server_name, host_vars)
         return inventory_dict

--- a/netbox/netbox.yml
+++ b/netbox/netbox.yml
@@ -3,6 +3,11 @@ netbox:
         api_url: 'http://localhost/api/dcim/devices/'
         #api_token: ''
 
+
+    # Determing the key/index of the inventory entry.
+    # In ansible terms that's the inventory_host_name.
+    host_key:
+        - name
     # How servers will be grouped.
     # If no group specified here, inventory script will return all servers.
     group_by:


### PR DESCRIPTION
Similar to the grouping and host vars, allow for complex composition of
the inventory_host_name. Defaulting to simple name is non-sustainable
over time as too restrictive and overfitted to certain use case.